### PR TITLE
Sync: Invalidate foreground and background colours

### DIFF
--- a/api.go
+++ b/api.go
@@ -485,5 +485,10 @@ func Sync() error {
 		return err
 	}
 
+	// invalidate foregound and background colours so the Flush() operation will
+	// ensure that colour attributes are sent to the terminal again.
+	lastfg = attr_invalid
+	lastbg = attr_invalid
+
 	return Flush()
 }


### PR DESCRIPTION
This ensures that the colour attributes are sent to the terminal again.

Connects https://github.com/thermeon/go-carsplus-login/issues/270