### PR TITLE
Add support for grabbing TTY input to bypass termbox-go's event processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED] - 0000-00-00
+### Added
+- GrabTtyInput() to allow applications to read from the TTY without termbox processing events
+
 ## [0.2.0] - 2018-02-27
 ### Changed
 - Reset the last used foreground and background colours in Sync() so they are re-sent to the terminal


### PR DESCRIPTION
termbox-go uses async IO to read data from the input stream and processes this data to generate events for the application. If the application reads data from STDIN in a synchronous manner, it prevents termbox-go from seeing that data because the async IO callback is made after it consumes at least some of the data in the stream. In such a situation, termbox-go is unable to process keystrokes to generate appropriate events.

`GrabTtyInput()` is a helper function that returns an `io.ReadCloser` that can be used by the application  to read data from STDIN, but through termbox's async IO read. This way, termbox acts as an intermediary between the application and the TTY.

When the `io.ReadCloser` is open, termbox-go doesn't generate any events. As soon as it is closed, termbox-go is able to resume its event generation process. This gives the application more control over exactly when termbox-go should be processing events.