### PR TITLE
Fix for cursor showing

### DIFF
--- a/api.go
+++ b/api.go
@@ -272,6 +272,8 @@ func Flush() error {
 	}
 	if !is_cursor_hidden(cursor_x, cursor_y) {
 		write_cursor(cursor_x, cursor_y)
+	}else {
+		outbuf.WriteString(funcs[t_hide_cursor])
 	}
 	return flush()
 }


### PR DESCRIPTION
The cursor was shown after redrawing but was hidden by a reset. So calling HideCursor in flush ensures hiding of the cursor is the last thing the terminal sees.
     
    Closes #297
