### PR TITLE
Input grabbing: Increase size of inpgrab channel

### DIFF
--- a/api.go
+++ b/api.go
@@ -87,8 +87,10 @@ func Init() error {
 						// inpgrab_ch channel instead of to the event handlers.
 						// This is done indirectly by sending a command to
 						// inpgrab, which is processed in another 'case' block.
+						outbuf := make([]byte, n)
+						copy(outbuf, buf[:n])
 						select {
-						case inpgrab <- inpgrab_ev{cmd: inpgrab_cmd_send_data, data: buf[:n]}:
+						case inpgrab <- inpgrab_ev{cmd: inpgrab_cmd_send_data, data: outbuf}:
 						case <-quit:
 							return
 						}

--- a/termbox.go
+++ b/termbox.go
@@ -154,7 +154,7 @@ var (
 	outbuf         bytes.Buffer
 	sigwinch       = make(chan os.Signal, 1)
 	sigio          = make(chan os.Signal, 1)
-	inpgrab        = make(chan inpgrab_ev, 1)
+	inpgrab        = make(chan inpgrab_ev, 1000)
 	inpgrab_res    = make(chan inpgrab_result, 1)
 	quit           = make(chan int)
 	input_comm     = make(chan input_event)


### PR DESCRIPTION
Having this channel size set to 1 caused random locking up of the select loop,
resulting in loss of input data. Increasing it to 1000 solves the immediate
issue of blocking, but a better solution would need to be found later on.

Since there'd be multiple items in the channel buffer now, the `buf[:n]` needs to be duplicated.