### PR TITLE
Unify the input grab channel sizes

### DIFF
--- a/api.go
+++ b/api.go
@@ -117,7 +117,7 @@ func Init() error {
 					if inpgrab_rc != nil {
 						res.err = fmt.Errorf("Input already grabbed")
 					} else {
-						inpgrab_ch = make(chan byte, 1)
+						inpgrab_ch = make(chan byte, cap(inpgrab))
 
 						res.rc = &inpgrab_read_closer{
 							in:       inpgrab_ch,
@@ -274,7 +274,7 @@ func Flush() error {
 	}
 	if !is_cursor_hidden(cursor_x, cursor_y) {
 		write_cursor(cursor_x, cursor_y)
-	}else {
+	} else {
 		outbuf.WriteString(funcs[t_hide_cursor])
 	}
 	return flush()


### PR DESCRIPTION
Make inpgrab_ch the same size as inpgrab, or we're just moving the
select lock further along the chain.