### PR TITLE
Input grabber: Fix goroutine deadlock

### DIFF
--- a/api.go
+++ b/api.go
@@ -85,14 +85,12 @@ func Init() error {
 					if inpgrab_ch != nil {
 						// If the input has been grabbed, send characters to the
 						// inpgrab_ch channel instead of to the event handlers.
-						// This is done indirectly by sending a command to
-						// inpgrab, which is processed in another 'case' block.
-						outbuf := make([]byte, n)
-						copy(outbuf, buf[:n])
-						select {
-						case inpgrab <- inpgrab_ev{cmd: inpgrab_cmd_send_data, data: outbuf}:
-						case <-quit:
-							return
+						for _, b := range buf[:n] {
+							select {
+							case inpgrab_ch <- b:
+							case <-quit:
+								return
+							}
 						}
 					} else {
 						select {
@@ -131,12 +129,6 @@ func Init() error {
 					close(inpgrab_ch)
 					inpgrab_ch = nil
 					inpgrab_rc = nil
-
-				case inpgrab_cmd_send_data:
-					// Send data to the io.ReadCloser
-					for _, b := range ev.data {
-						inpgrab_ch <- b
-					}
 				}
 			case <-quit:
 				return

--- a/termbox.go
+++ b/termbox.go
@@ -58,7 +58,6 @@ type inpgrab_cmd int
 const (
 	inpgrab_cmd_grab = iota
 	inpgrab_cmd_release
-	inpgrab_cmd_send_data
 )
 
 // inpgrab_ev is an input grab event


### PR DESCRIPTION
(The code is shorter than the following wall of text, so feel free to ignore this)

When the TTY input was grabbed, the `sigio` case block in the select sent a
message on the `inpgrab` channel, which in turn sent data to the `inpgrab_ch`
channel for the application to read from. The `inpgrab` case block is in the
same select block as the `sigio` case block, and this caused a deadlock.

This was because when input data came in too fast, it was possible for the
`inpgrab` channel's buffer to be full, making the channel send operation from
the `sigio` block to be blocked. Since the operation to read from the `inpgrab`
channel was in the same select block, it never got executed.

The fix removes the deadlock by directly sending input data to the `inpgrab_ch`
channel in the `sigio` case block. That channel gets drained whenever the
application reads from it.